### PR TITLE
Bug patch t5 cargo

### DIFF
--- a/Data/BlockVariantGroups.sbc
+++ b/Data/BlockVariantGroups.sbc
@@ -264,7 +264,7 @@
                 <Block Type="MyObjectBuilder_OxygenTank" Subtype="SmallHydrogenTankSmall8x" />
                 <Block Type="MyObjectBuilder_OxygenTank" Subtype="SmallHydrogenTank8x" />
                 <Block Type="MyObjectBuilder_OxygenTank" Subtype="LargeHydrogenTank20x" />
-                <Block Type="MyObjectBuilder_OxygenTank" Subtype="LargeBlockLargeContainer50x" />
+                <!-- <Block Type="MyObjectBuilder_OxygenTank" Subtype="LargeBlockLargeContainer50x" /> -->
             </Blocks>
         </BlockVariantGroup>
 
@@ -301,7 +301,8 @@
               <Block Type="MyObjectBuilder_CargoContainer" Subtype="SmallBlockLargeContainer8x" />
               <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLargeIndustrialContainer8x" />
               <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLargeContainer20x" />
-              <Block Type="MyObjectBuilder_OxygenTank" Subtype="LargeBlockLargeContainer50x" />
+              <!-- <Block Type="MyObjectBuilder_OxygenTank" Subtype="LargeBlockLargeContainer50x" /> -->
+              <Block Type="MyObjectBuilder_CargoContainer" Subtype="LargeBlockLargeContainer50xReplace" />
             </Blocks>
         </BlockVariantGroup>
 

--- a/Data/CubeBlocks_CargoContainerLarge.sbc
+++ b/Data/CubeBlocks_CargoContainerLarge.sbc
@@ -408,6 +408,7 @@
             </Id>
             <DisplayName>The Vault, Cargo</DisplayName>
             <GuiVisible>false</GuiVisible>
+            <Public>false</Public>
             <Icon>Textures\VaultCargo.dds</Icon>
             <Description>Combination Hydrogen and Cargo container of massive efficiency. No warchest is complete without one. Utilizing advanced cooling and compression, hydrogen is locked away, while separate compartments store all the materials you require to produce hundreds of warships at a moment's notice. Just one should be all that you require.
 			
@@ -498,6 +499,74 @@
                 <unsignedInt>600</unsignedInt>
             </TieredUpdateTimes>
             <PCU>25</PCU>
+        </Definition>
+
+
+                <!-- This one will replace the hybrid cargo tank in the future -->
+		<Definition xsi:type="MyObjectBuilder_CargoContainerDefinition">
+            <Id>
+                <TypeId>CargoContainer</TypeId>
+                <SubtypeId>LargeBlockLargeContainer50xReplace</SubtypeId>
+            </Id>
+            <DisplayName>Vault One-O-Eight</DisplayName>
+            <GuiVisible>false</GuiVisible>
+            <Icon>Textures\VaultCargo.dds</Icon>
+            <Description>Description_LargeCargoContainer</Description>
+            <CubeSize>Large</CubeSize>
+            <BlockTopology>TriangleMesh</BlockTopology>
+            <Size x="7" y="3" z="11" />
+            <ModelOffset x="0" y="0" z="0"/>
+            <Model>Models\XLCargo\VaultCargo.mwm</Model>
+            <Components>
+                <Component Subtype="Tech50x" Count="6"/>
+                <Component Subtype="InteriorPlate" Count="3000"/>
+                <Component Subtype="Construction" Count="2500"/>
+                <Component Subtype="SmallTube" Count="8000"/>
+                <Component Subtype="LargeTube" Count="7890"/>
+                <Component Subtype="Motor" Count="1500"/>
+                <Component Subtype="Computer" Count="1984"/>
+                <Component Subtype="Display" Count="50"/>
+                <Component Subtype="SteelPlate" Count="4000"/>
+            </Components>
+            <CriticalComponent Subtype="Computer" Index="0"/>
+			<MountPoints>
+				<MountPoint Side="Front" StartX="0.15" StartY="0.15" EndX="2.85" EndY="2.85"/>
+				<MountPoint Side="Front" StartX="4.15" StartY="0.15" EndX="6.85" EndY="2.85"/>
+				<MountPoint Side="Front" StartX="3.1" StartY="1.1" EndX="3.9" EndY="1.9"/>
+				<MountPoint Side="Back" StartX="0.15" StartY="0.15" EndX="2.85" EndY="2.85"/>
+				<MountPoint Side="Back" StartX="4.15" StartY="0.15" EndX="6.85" EndY="2.85"/>
+				<MountPoint Side="Back" StartX="3.1" StartY="1.1" EndX="3.9" EndY="1.9"/>
+				<MountPoint Side="Left" StartX="0.04" StartY="0.52" EndX="10.96" EndY="2.48"/>
+				<MountPoint Side="Right" StartX="0.04" StartY="0.52" EndX="10.96" EndY="2.48"/>
+				<MountPoint Side="Top" StartX="0.56" StartY="0.04" EndX="2.44" EndY="10.96"/>
+				<MountPoint Side="Top" StartX="4.56" StartY="0.04" EndX="6.44" EndY="10.96"/>
+				<MountPoint Side="Top" StartX="3.1" StartY="5.1" EndX="3.9" EndY="5.9"/>
+				<MountPoint Side="Bottom" StartX="0.56" StartY="0.04" EndX="2.44" EndY="10.96"/>
+				<MountPoint Side="Bottom" StartX="4.56" StartY="0.04" EndX="6.44" EndY="10.96"/>
+				<MountPoint Side="Bottom" StartX="3.1" StartY="5.1" EndX="3.9" EndY="5.9"/>
+			</MountPoints>
+            <BuildProgressModels>
+                <Model BuildPercentUpperBound="0.20" File="Models\XLCargo\VaultCargo_BS1.mwm"/>
+                <Model BuildPercentUpperBound="0.40" File="Models\XLCargo\VaultCargo_BS2.mwm"/>
+                <Model BuildPercentUpperBound="0.60" File="Models\XLCargo\VaultCargo_BS3.mwm"/>
+                <Model BuildPercentUpperBound="1.00" File="Models\XLCargo\VaultCargo_BS4.mwm"/>
+            </BuildProgressModels>
+            <BlockPairName>GarysVault</BlockPairName>
+            <MirroringY>Z</MirroringY>
+            <MirroringZ>Y</MirroringZ>
+            <EdgeType>Heavy</EdgeType>
+            <BuildTimeSeconds>2000</BuildTimeSeconds>
+            <GeneralDamageMultiplier>0.8</GeneralDamageMultiplier>
+            <DamageEffectName>Damage_HeavyMech_Damaged</DamageEffectName>
+            <DamagedSound>ParticleHeavyMech</DamagedSound>
+            <DestroyEffect>BlockDestroyedExplosion_Large</DestroyEffect>
+            <DestroySound>WepSmallWarheadExpl</DestroySound>
+            <PCU>25</PCU>
+            <InventorySize>
+                <X>400000</X>
+                <Y>1</Y>
+                <Z>1</Z>
+            </InventorySize>
         </Definition>
 
     </CubeBlocks>


### PR DESCRIPTION
Create T5 cargo-only to fix bug of inventory not being able to automatically go into any production blocks or welders.
Hide old T5 hybrid container from view to prevent players from building more of them.